### PR TITLE
NO_ISSUE: Fix prod nightly - remove kogito-addons-springboot-embedded…

### DIFF
--- a/productized/modules
+++ b/productized/modules
@@ -14,4 +14,5 @@ data-index/data-index-storage/pom.xml;data-index-storage-common,data-index-stora
 data-index/pom.xml;data-index-springboot
 jitexecutor/pom.xml;jitexecutor-bpmn
 jobs-service/pom.xml;jobs-service-infinispan,jobs-service-mongodb
+jobs/pom.xml;kogito-addons-springboot-embedded-jobs
 persistence-commons/pom.xml;persistence-commons-mongodb,persistence-commons-redis,persistence-commons-reporting-parent,persistence-commons-mongodb-quarkus


### PR DESCRIPTION
…-jobs

Depends on already excluded module kie-addons-springboot-flyway and we do not need springboot modules in product.

@fjtirado and @gmunozfe FYI

Fixes nightly product build on Jenkins environment that uses these scripts