### PR TITLE
[SRVLOGIC-963] Changes for snapshots publishing.

### DIFF
--- a/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-common/pom.xml
+++ b/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>integration-tests-data-index-service</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-quarkus-devservice/pom.xml
+++ b/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-quarkus-devservice/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>integration-tests-data-index-service</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>integration-tests-data-index-service</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-springboot/pom.xml
+++ b/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-springboot/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>integration-tests-data-index-service</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/apps-integration-tests/integration-tests-data-index-service/pom.xml
+++ b/apps-integration-tests/integration-tests-data-index-service/pom.xml
@@ -35,9 +35,6 @@
 
   <modules>
     <module>integration-tests-data-index-service-quarkus-devservice</module>
-    <module>integration-tests-data-index-service-common</module>
-    <module>integration-tests-data-index-service-quarkus</module>
-    <module>integration-tests-data-index-service-springboot</module>
   </modules>
 
   <dependencyManagement>

--- a/apps-integration-tests/integration-tests-data-index-service/pom.xml
+++ b/apps-integration-tests/integration-tests-data-index-service/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>apps-integration-tests</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-common/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-common/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests-jobs-service</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>integration-tests-jobs-service-common</artifactId>

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-common-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-common-quarkus/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>integration-tests-jobs-service</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-embedded/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-embedded/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests-jobs-service-quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-jobs-service-quarkus-embedded</artifactId>
   <name>Kogito Apps :: Integration Tests :: Jobs Service :: Quarkus :: embedded</name>

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-knative-eventing/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-knative-eventing/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests-jobs-service-quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>integration-tests-jobs-service-quarkus-knative-eventing</artifactId>

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-management/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-management/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests-jobs-service-quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-jobs-service-quarkus-management</artifactId>
   <name>Kogito Apps :: Integration Tests :: Jobs Service :: Quarkus :: Management</name>

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-messaging/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-messaging/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests-jobs-service-quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-jobs-service-quarkus-messaging</artifactId>
   <name>Kogito Apps :: Integration Tests :: Jobs Service :: Quarkus :: Messaging</name>

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/pom.xml
@@ -37,9 +37,6 @@
 
   <modules>
     <module>integration-tests-jobs-service-common-quarkus</module>
-    <module>integration-tests-jobs-service-quarkus-management</module>
-    <module>integration-tests-jobs-service-quarkus-messaging</module>
-    <module>integration-tests-jobs-service-quarkus-knative-eventing</module>
     <module>integration-tests-jobs-service-quarkus-embedded</module>
   </modules>
 </project>

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests-jobs-service</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-jobs-service-quarkus</artifactId>
   <name>Kogito Apps :: Integration Tests :: Jobs Service :: Quarkus</name>

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-springboot/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-springboot/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests-jobs-service</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-jobs-service-springboot</artifactId>
   <name>Kogito Apps :: Integration Tests :: Jobs Service :: Spring Boot</name>

--- a/apps-integration-tests/integration-tests-jobs-service/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/pom.xml
@@ -37,7 +37,6 @@
   <modules>
     <module>integration-tests-jobs-service-common</module>
     <module>integration-tests-jobs-service-quarkus</module>
-    <module>integration-tests-jobs-service-springboot</module>
   </modules>
 
   <dependencyManagement>

--- a/apps-integration-tests/integration-tests-jobs-service/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>apps-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>integration-tests-jobs-service</artifactId>

--- a/apps-integration-tests/integration-tests-jobs/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>apps-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>integration-tests-jobs</artifactId>

--- a/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-common/pom.xml
+++ b/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-common/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests-trusty-service</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>integration-tests-trusty-service-common</artifactId>

--- a/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-quarkus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests-trusty-service</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-trusty-service-quarkus</artifactId>
   <name>Kogito Apps :: Integration Tests :: Trusty Service :: Quarkus</name>

--- a/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-springboot/pom.xml
+++ b/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-springboot/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests-trusty-service</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-trusty-service-springboot</artifactId>
   <name>Kogito Apps :: Integration Tests :: Trusty Service :: Spring Boot</name>

--- a/apps-integration-tests/integration-tests-trusty-service/pom.xml
+++ b/apps-integration-tests/integration-tests-trusty-service/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>apps-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>integration-tests-trusty-service</artifactId>

--- a/apps-integration-tests/pom.xml
+++ b/apps-integration-tests/pom.xml
@@ -36,7 +36,6 @@
 
   <modules>
     <module>integration-tests-data-index-service</module>
-    <module>integration-tests-jobs</module>
     <module>integration-tests-jobs-service</module>
   </modules>
 

--- a/apps-integration-tests/pom.xml
+++ b/apps-integration-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-apps-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-apps-build-parent/pom.xml</relativePath>
   </parent>
   <artifactId>apps-integration-tests</artifactId>

--- a/data-audit/data-audit-common-service/pom.xml
+++ b/data-audit/data-audit-common-service/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>data-audit</artifactId>
 		<groupId>org.kie.kogito</groupId>
-		<version>999-SNAPSHOT</version>
+		<version>111-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>data-audit-common-service</artifactId>

--- a/data-audit/data-audit-common/pom.xml
+++ b/data-audit/data-audit-common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>data-audit</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>data-audit-common</artifactId>
     <name>Kogito Apps :: Data Audit :: Common</name>

--- a/data-audit/data-audit-quarkus-service/pom.xml
+++ b/data-audit/data-audit-quarkus-service/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>data-audit</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
 

--- a/data-audit/kogito-addons-data-audit-jpa/data-audit-quarkus-jpa-service/pom.xml
+++ b/data-audit/kogito-addons-data-audit-jpa/data-audit-quarkus-jpa-service/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kogito-addons-data-audit-jpa</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>data-audit-quarkus-jpa-service</artifactId>

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/pom.xml
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.kie</groupId>
 		<artifactId>kogito-addons-data-audit-jpa</artifactId>
-		<version>999-SNAPSHOT</version>
+		<version>111-SNAPSHOT</version>
 	</parent>
 	<artifactId>kogito-addons-data-audit-jpa-common</artifactId>
 	<name>Kogito Apps :: Data Audit :: JPA :: Common</name>

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-quarkus/pom.xml
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-quarkus/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-data-audit-jpa</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-data-audit-jpa</artifactId>

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-springboot/pom.xml
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-springboot/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-data-audit-jpa</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-springboot-data-audit-jpa</artifactId>

--- a/data-audit/kogito-addons-data-audit-jpa/pom.xml
+++ b/data-audit/kogito-addons-data-audit-jpa/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>data-audit</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/data-audit/kogito-addons-data-audit-quarkus/pom.xml
+++ b/data-audit/kogito-addons-data-audit-quarkus/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>data-audit</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.kie</groupId>

--- a/data-audit/kogito-addons-data-audit-springboot/pom.xml
+++ b/data-audit/kogito-addons-data-audit-springboot/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>data-audit</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.kie</groupId>

--- a/data-audit/pom.xml
+++ b/data-audit/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-apps-build-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
         <relativePath>../kogito-apps-build-parent/pom.xml</relativePath>
     </parent>
 

--- a/data-index/data-index-common-addons/pom.xml
+++ b/data-index/data-index-common-addons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>data-index</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-common/pom.xml
+++ b/data-index/data-index-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>data-index</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-graphql-addons/pom.xml
+++ b/data-index/data-index-graphql-addons/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>data-index</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-graphql/pom.xml
+++ b/data-index/data-index-graphql/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>data-index</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-mutations/data-index-shared-output-mutation/pom.xml
+++ b/data-index/data-index-mutations/data-index-shared-output-mutation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-mutations</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>data-index-shared-output-mutation</artifactId>
   <dependencies>

--- a/data-index/data-index-mutations/pom.xml
+++ b/data-index/data-index-mutations/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>data-index-mutations</artifactId>
   <packaging>pom</packaging>

--- a/data-index/data-index-quarkus/data-index-common-quarkus/pom.xml
+++ b/data-index/data-index-quarkus/data-index-common-quarkus/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <properties>
     <java.module.name>org.kie.kogito.index.quarkus</java.module.name>

--- a/data-index/data-index-quarkus/data-index-graphql-quarkus/pom.xml
+++ b/data-index/data-index-quarkus/data-index-graphql-quarkus/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>data-index-graphql-quarkus</artifactId>
     <properties>

--- a/data-index/data-index-quarkus/data-index-service-inmemory/pom.xml
+++ b/data-index/data-index-quarkus/data-index-service-inmemory/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>data-index-quarkus</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-quarkus/data-index-service-mongodb/pom.xml
+++ b/data-index/data-index-quarkus/data-index-service-mongodb/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>data-index-quarkus</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-quarkus/data-index-service-postgresql/pom.xml
+++ b/data-index/data-index-quarkus/data-index-service-postgresql/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>data-index-quarkus</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-quarkus/data-index-service-quarkus-common/pom.xml
+++ b/data-index/data-index-quarkus/data-index-service-quarkus-common/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>data-index-service-quarkus-common</artifactId>
    <name>Kogito Apps :: Data Index Service Common Quarkus</name>

--- a/data-index/data-index-quarkus/data-index-storage-jpa-quarkus/pom.xml
+++ b/data-index/data-index-quarkus/data-index-storage-jpa-quarkus/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>data-index-quarkus</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-common/deployment/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-common/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-common-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-common-deployment</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence Common :: Deployment</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-common/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-common-parent</artifactId>
   <packaging>pom</packaging>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-common/runtime/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-common/runtime/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-data-index-persistence-common-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kogito-addons-quarkus-data-index-persistence-common-runtime</artifactId>
     <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence Common :: Runtime</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/deployment/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-jpa-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-jpa-deployment</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence JPA :: Deployment</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/integration-tests-process/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/integration-tests-process/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-jpa-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-jpa-integration-tests-process</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence JPA :: Integration Tests :: Process</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/integration-tests-sw/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/integration-tests-sw/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-jpa-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-jpa-integration-tests-sw</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence JPA :: Integration Tests :: SW</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/pom.xml
@@ -39,7 +39,6 @@
   <modules>
     <module>deployment</module>
     <module>runtime</module>
-    <module>integration-tests-process</module>
     <module>integration-tests-sw</module>
   </modules>
 

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-jpa-parent</artifactId>
   <packaging>pom</packaging>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/runtime/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-jpa/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-jpa-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-jpa</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence JPA :: Runtime</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/deployment/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-mongodb-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-mongodb-deployment</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence MongoDB :: Deployment</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/integration-tests-process/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/integration-tests-process/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-mongodb-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-mongodb-persistence-integration-tests-process</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence MongoDB :: Integration Tests :: Process</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/integration-tests-sw/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/integration-tests-sw/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-mongodb-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-mongodb-integration-tests-sw</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence MongoDB :: Integration Tests :: SW</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-mongodb-parent</artifactId>
   <packaging>pom</packaging>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/runtime/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-mongodb/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-mongodb-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-mongodb</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence MongoDB :: Runtime</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/deployment/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-postgresql-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-postgresql-deployment</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence PostgreSQL :: Deployment</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/integration-tests-process/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/integration-tests-process/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-postgresql-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-postgresql-integration-tests-process</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence PostgreSQL :: Integration Tests :: Process</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/integration-tests-sw/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/integration-tests-sw/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-postgresql-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-postgresql-integration-tests-sw</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence PostgreSQL :: Integration Tests :: SW</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/pom.xml
@@ -40,7 +40,6 @@
     <module>deployment</module>
     <module>runtime</module>
     <module>integration-tests-sw</module>
-    <module>integration-tests-process</module>
   </modules>
 
 </project>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-postgresql-parent</artifactId>
   <packaging>pom</packaging>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/runtime/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/kogito-addons-quarkus-data-index-persistence-postgresql/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-persistence-postgresql-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-persistence-postgresql</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Persistence PostgreSQL :: Runtime</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/pom.xml
@@ -37,7 +37,6 @@
     <module>kogito-addons-quarkus-data-index-persistence-common</module>
     <module>kogito-addons-quarkus-data-index-persistence-postgresql</module>
     <module>kogito-addons-quarkus-data-index-persistence-jpa</module>
-    <module>kogito-addons-quarkus-data-index-persistence-mongodb</module>
   </modules>
 
 </project>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index-persistence/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/deployment/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-common-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-common-deployment</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index Common :: Deployment</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-common-parent</artifactId>
   <packaging>pom</packaging>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/runtime/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/runtime/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-data-index-common-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kogito-addons-quarkus-data-index-common-runtime</artifactId>
     <name>Kogito Apps :: Kogito Addons Quarkus Data Index Common :: Runtime</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/deployment/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-inmemory-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-inmemory-deployment</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index In-memory :: Deployment</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/integration-tests-process/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/integration-tests-process/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-inmemory-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-inmemory-integration-tests-process</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index In-memory :: Integration Tests :: Process</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/integration-tests-sw/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/integration-tests-sw/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-inmemory-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-inmemory-integration-tests-sw</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index In-memory :: Integration Tests :: SW</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/pom.xml
@@ -40,7 +40,6 @@
     <module>deployment</module>
     <module>runtime</module>
     <module>integration-tests-sw</module>
-    <module>integration-tests-process</module>
   </modules>
 
 </project>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-inmemory-parent</artifactId>
   <packaging>pom</packaging>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/runtime/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-inmemory-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-inmemory</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index In-memory :: Runtime</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/deployment/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-jpa-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-jpa-deployment</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index JPA :: Deployment</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/integration-tests-process/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/integration-tests-process/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-jpa-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-jpa-integration-tests-process</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index JPA :: Integration Tests :: Process</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/integration-tests-sw/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/integration-tests-sw/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-jpa-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-jpa-integration-tests-sw</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index JPA :: Integration Tests :: SW</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/pom.xml
@@ -40,7 +40,6 @@
     <module>deployment</module>
     <module>runtime</module>
     <module>integration-tests-sw</module>
-    <module>integration-tests-process</module>
   </modules>
 
 </project>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-jpa-parent</artifactId>
   <packaging>pom</packaging>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/runtime/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-jpa/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-jpa-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-jpa</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index JPA :: Runtime</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/deployment/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-mongodb-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-mongodb-deployment</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index MongoDB :: Deployment</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/integration-tests-process/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/integration-tests-process/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-mongodb-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-mongodb-integration-tests-process</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index MongoDB :: Integration Tests :: Process</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/integration-tests-sw/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/integration-tests-sw/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-mongodb-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-mongodb-integration-tests-sw</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index MongoDB :: Integration Tests :: SW</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-mongodb-parent</artifactId>
   <packaging>pom</packaging>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/runtime/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-mongodb-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-mongodb</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index MongoDB :: Runtime</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/deployment/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-postgresql-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-postgresql-deployment</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index PostgreSQL :: Deployment</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/integration-tests-process/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/integration-tests-process/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-postgresql-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-postgresql-integration-tests-process</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index PostgreSQL :: Integration Tests :: Process</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/integration-tests-sw/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/integration-tests-sw/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-postgresql-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-postgresql-integration-tests-sw</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index PostgreSQL :: Integration Tests :: SW</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/pom.xml
@@ -40,7 +40,6 @@
     <module>deployment</module>
     <module>runtime</module>
     <module>integration-tests-sw</module>
-    <module>integration-tests-process</module>
   </modules>
 
 </project>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-postgresql-parent</artifactId>
   <packaging>pom</packaging>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/runtime/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-data-index-postgresql-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-data-index-postgresql</artifactId>
   <name>Kogito Apps :: Kogito Addons Quarkus Data Index PostgreSQL :: Runtime</name>

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/pom.xml
@@ -37,7 +37,6 @@
     <module>kogito-addons-quarkus-data-index-common</module>
     <module>kogito-addons-quarkus-data-index-inmemory</module>
     <module>kogito-addons-quarkus-data-index-postgresql</module>
-    <module>kogito-addons-quarkus-data-index-mongodb</module>
     <module>kogito-addons-quarkus-data-index-jpa</module>
   </modules>
 

--- a/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/pom.xml
+++ b/data-index/data-index-quarkus/kogito-addons-quarkus-data-index/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/data-index/data-index-quarkus/pom.xml
+++ b/data-index/data-index-quarkus/pom.xml
@@ -32,7 +32,6 @@
     <module>data-index-graphql-quarkus</module>
     <module>data-index-service-inmemory</module>
     <module>data-index-service-postgresql</module>
-    <module>data-index-service-mongodb</module>
     <module>data-index-service-quarkus-common</module>
     <module>data-index-storage-jpa-quarkus</module>
     <module>kogito-addons-quarkus-data-index-persistence</module>

--- a/data-index/data-index-quarkus/pom.xml
+++ b/data-index/data-index-quarkus/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>data-index-quarkus</artifactId>
   <packaging>pom</packaging>

--- a/data-index/data-index-service/data-index-service-common/pom.xml
+++ b/data-index/data-index-service/data-index-service-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>data-index-service</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-service/pom.xml
+++ b/data-index/data-index-service/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>data-index-service</artifactId>
   <name>Kogito Apps :: Data Index Service</name>

--- a/data-index/data-index-springboot/data-index-common-addons-springboot/pom.xml
+++ b/data-index/data-index-springboot/data-index-common-addons-springboot/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>data-index-springboot</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>data-index-common-addons-springboot</artifactId>

--- a/data-index/data-index-springboot/data-index-common-springboot/pom.xml
+++ b/data-index/data-index-springboot/data-index-common-springboot/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-springboot</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>data-index-common-springboot</artifactId>

--- a/data-index/data-index-springboot/data-index-graphql-addons-springboot/pom.xml
+++ b/data-index/data-index-springboot/data-index-graphql-addons-springboot/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>data-index-springboot</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-springboot/data-index-storage-jpa-springboot/pom.xml
+++ b/data-index/data-index-springboot/data-index-storage-jpa-springboot/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>data-index-springboot</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>data-index-storage-jpa-springboot</artifactId>

--- a/data-index/data-index-springboot/kogito-addons-springboot-data-index-persistence/kogito-addons-springboot-data-index-persistence-jpa-parent/integration-tests-process/pom.xml
+++ b/data-index/data-index-springboot/kogito-addons-springboot-data-index-persistence/kogito-addons-springboot-data-index-persistence-jpa-parent/integration-tests-process/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-springboot-data-index-persistence-jpa-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-springboot-data-index-persistence-jpa-integration-tests-process</artifactId>

--- a/data-index/data-index-springboot/kogito-addons-springboot-data-index-persistence/kogito-addons-springboot-data-index-persistence-jpa-parent/kogito-addons-springboot-data-index-persistence-jpa/pom.xml
+++ b/data-index/data-index-springboot/kogito-addons-springboot-data-index-persistence/kogito-addons-springboot-data-index-persistence-jpa-parent/kogito-addons-springboot-data-index-persistence-jpa/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-springboot-data-index-persistence-jpa-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-springboot-data-index-persistence-jpa</artifactId>

--- a/data-index/data-index-springboot/kogito-addons-springboot-data-index-persistence/kogito-addons-springboot-data-index-persistence-jpa-parent/pom.xml
+++ b/data-index/data-index-springboot/kogito-addons-springboot-data-index-persistence/kogito-addons-springboot-data-index-persistence-jpa-parent/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-springboot-data-index-persistence</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-springboot-data-index-persistence-jpa-parent</artifactId>

--- a/data-index/data-index-springboot/kogito-addons-springboot-data-index-persistence/pom.xml
+++ b/data-index/data-index-springboot/kogito-addons-springboot-data-index-persistence/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-springboot</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/data-index/data-index-springboot/kogito-addons-springboot-data-index/kogito-addons-springboot-data-index-jpa-parent/integration-tests-process/pom.xml
+++ b/data-index/data-index-springboot/kogito-addons-springboot-data-index/kogito-addons-springboot-data-index-jpa-parent/integration-tests-process/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-springboot-data-index-jpa-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-springboot-data-index-jpa-integration-tests-process</artifactId>

--- a/data-index/data-index-springboot/kogito-addons-springboot-data-index/kogito-addons-springboot-data-index-jpa-parent/kogito-addons-springboot-data-index-jpa/pom.xml
+++ b/data-index/data-index-springboot/kogito-addons-springboot-data-index/kogito-addons-springboot-data-index-jpa-parent/kogito-addons-springboot-data-index-jpa/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-springboot-data-index-jpa-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-springboot-data-index-jpa</artifactId>

--- a/data-index/data-index-springboot/kogito-addons-springboot-data-index/kogito-addons-springboot-data-index-jpa-parent/pom.xml
+++ b/data-index/data-index-springboot/kogito-addons-springboot-data-index/kogito-addons-springboot-data-index-jpa-parent/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-springboot-data-index</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-springboot-data-index-jpa-parent</artifactId>

--- a/data-index/data-index-springboot/kogito-addons-springboot-data-index/pom.xml
+++ b/data-index/data-index-springboot/kogito-addons-springboot-data-index/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>data-index-springboot</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.kie</groupId>

--- a/data-index/data-index-springboot/pom.xml
+++ b/data-index/data-index-springboot/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>data-index-springboot</artifactId>

--- a/data-index/data-index-storage/data-index-storage-api/pom.xml
+++ b/data-index/data-index-storage/data-index-storage-api/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-storage</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>data-index-storage-api</artifactId>
   <name>Kogito Apps :: Data Index Storage API</name>

--- a/data-index/data-index-storage/data-index-storage-common/pom.xml
+++ b/data-index/data-index-storage/data-index-storage-common/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-storage</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>data-index-storage-common</artifactId>
   <name>Kogito Apps :: Data Index Storage Common</name>

--- a/data-index/data-index-storage/data-index-storage-infinispan/pom.xml
+++ b/data-index/data-index-storage/data-index-storage-infinispan/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-storage</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-storage/data-index-storage-jpa-common/pom.xml
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-storage</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-storage/data-index-storage-jpa/pom.xml
+++ b/data-index/data-index-storage/data-index-storage-jpa/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-storage</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-storage/data-index-storage-mongodb/pom.xml
+++ b/data-index/data-index-storage/data-index-storage-mongodb/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-storage</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-storage/data-index-storage-postgresql-reporting/pom.xml
+++ b/data-index/data-index-storage/data-index-storage-postgresql-reporting/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-storage</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-storage/data-index-storage-postgresql/pom.xml
+++ b/data-index/data-index-storage/data-index-storage-postgresql/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-storage</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-storage/data-index-storage-protobuf/pom.xml
+++ b/data-index/data-index-storage/data-index-storage-protobuf/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-storage</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-storage/pom.xml
+++ b/data-index/data-index-storage/pom.xml
@@ -37,9 +37,6 @@
     <module>data-index-storage-protobuf</module>
     <module>data-index-storage-postgresql</module>
     <module>data-index-storage-jpa-common</module>
-    <module>data-index-storage-common</module>
-    <module>data-index-storage-mongodb</module>
-    <module>data-index-storage-postgresql-reporting</module>
     <module>data-index-storage-jpa</module>
   </modules>
 </project>

--- a/data-index/data-index-storage/pom.xml
+++ b/data-index/data-index-storage/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/data-index-test-utils/pom.xml
+++ b/data-index/data-index-test-utils/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>data-index</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/data-index/pom.xml
+++ b/data-index/pom.xml
@@ -44,7 +44,6 @@
     <module>data-index-mutations</module>
     <module>data-index-common-addons</module>
     <module>data-index-quarkus</module>
-    <module>data-index-springboot</module>
   </modules>
 
 </project>

--- a/data-index/pom.xml
+++ b/data-index/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-apps-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-apps-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/explainability/explainability-api/pom.xml
+++ b/explainability/explainability-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>explainability</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/explainability/explainability-service-messaging/pom.xml
+++ b/explainability/explainability-service-messaging/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>explainability</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/explainability/explainability-service-rest/pom.xml
+++ b/explainability/explainability-service-rest/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>explainability</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/explainability/explainability-service/pom.xml
+++ b/explainability/explainability-service/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>explainability</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/explainability/pom.xml
+++ b/explainability/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-apps-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-apps-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jitexecutor-native/jitexecutor-native-darwin/pom.xml
+++ b/jitexecutor-native/jitexecutor-native-darwin/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jitexecutor-native</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jitexecutor-native-darwin</artifactId>

--- a/jitexecutor-native/jitexecutor-native-linux/pom.xml
+++ b/jitexecutor-native/jitexecutor-native-linux/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jitexecutor-native</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jitexecutor-native-linux</artifactId>

--- a/jitexecutor-native/jitexecutor-native-win32/pom.xml
+++ b/jitexecutor-native/jitexecutor-native-win32/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jitexecutor-native</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jitexecutor-native-win32</artifactId>

--- a/jitexecutor-native/pom.xml
+++ b/jitexecutor-native/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-apps-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-apps-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jitexecutor/jitexecutor-bpmn/pom.xml
+++ b/jitexecutor/jitexecutor-bpmn/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>jitexecutor</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jitexecutor-bpmn</artifactId>

--- a/jitexecutor/jitexecutor-common/pom.xml
+++ b/jitexecutor/jitexecutor-common/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jitexecutor</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jitexecutor-common</artifactId>

--- a/jitexecutor/jitexecutor-dmn/pom.xml
+++ b/jitexecutor/jitexecutor-dmn/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>jitexecutor</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jitexecutor-dmn</artifactId>

--- a/jitexecutor/jitexecutor-runner/pom.xml
+++ b/jitexecutor/jitexecutor-runner/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>jitexecutor</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/jitexecutor/pom.xml
+++ b/jitexecutor/pom.xml
@@ -35,7 +35,6 @@
 
   <modules>
     <module>jitexecutor-common</module>
-    <module>jitexecutor-bpmn</module>
     <module>jitexecutor-dmn</module>
     <module>jitexecutor-runner</module>
   </modules>

--- a/jitexecutor/pom.xml
+++ b/jitexecutor/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-apps-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-apps-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jobs-service/jobs-recipients/job-http-recipient/deployment/pom.xml
+++ b/jobs-service/jobs-recipients/job-http-recipient/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-job-http-recipient-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-job-http-recipient-deployment</artifactId>
   <name>Kogito Apps :: Jobs Service :: Kogito Add-Ons Quarkus Job Http Recipient - Deployment</name>

--- a/jobs-service/jobs-recipients/job-http-recipient/pom.xml
+++ b/jobs-service/jobs-recipients/job-http-recipient/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jobs-recipients</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/jobs-service/jobs-recipients/job-http-recipient/runtime/pom.xml
+++ b/jobs-service/jobs-recipients/job-http-recipient/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-job-http-recipient-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-job-http-recipient</artifactId>
   <name>Kogito Apps :: Jobs Service :: Kogito Add-Ons Quarkus Job Http Recipient - Runtime</name>

--- a/jobs-service/jobs-recipients/job-recipient-common-http/pom.xml
+++ b/jobs-service/jobs-recipients/job-recipient-common-http/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>jobs-recipients</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jobs-service/jobs-recipients/job-sink-recipient/deployment/pom.xml
+++ b/jobs-service/jobs-recipients/job-sink-recipient/deployment/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-job-sink-recipient-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-addons-quarkus-job-sink-recipient-deployment</artifactId>

--- a/jobs-service/jobs-recipients/job-sink-recipient/pom.xml
+++ b/jobs-service/jobs-recipients/job-sink-recipient/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>jobs-recipients</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jobs-service/jobs-recipients/job-sink-recipient/runtime/pom.xml
+++ b/jobs-service/jobs-recipients/job-sink-recipient/runtime/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-job-sink-recipient-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-addons-quarkus-job-sink-recipient</artifactId>

--- a/jobs-service/jobs-recipients/pom.xml
+++ b/jobs-service/jobs-recipients/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>jobs-service</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>jobs-recipients</artifactId>
     <name>Kogito Apps :: Jobs Service :: Jobs Recipients</name>

--- a/jobs-service/jobs-service-common/pom.xml
+++ b/jobs-service/jobs-service-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jobs-service</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jobs-service-common</artifactId>

--- a/jobs-service/jobs-service-infinispan/pom.xml
+++ b/jobs-service/jobs-service-infinispan/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>jobs-service</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jobs-service-infinispan</artifactId>

--- a/jobs-service/jobs-service-inmemory/pom.xml
+++ b/jobs-service/jobs-service-inmemory/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>jobs-service</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jobs-service-inmemory</artifactId>

--- a/jobs-service/jobs-service-internal-api/pom.xml
+++ b/jobs-service/jobs-service-internal-api/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>jobs-service</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jobs-service-internal-api</artifactId>

--- a/jobs-service/jobs-service-messaging-http/pom.xml
+++ b/jobs-service/jobs-service-messaging-http/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>jobs-service</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jobs-service/jobs-service-messaging-kafka/pom.xml
+++ b/jobs-service/jobs-service-messaging-kafka/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>jobs-service</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jobs-service/jobs-service-mongodb/pom.xml
+++ b/jobs-service/jobs-service-mongodb/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>jobs-service</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jobs-service-mongodb</artifactId>

--- a/jobs-service/jobs-service-postgresql-common/pom.xml
+++ b/jobs-service/jobs-service-postgresql-common/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>jobs-service</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jobs-service-postgresql-common</artifactId>

--- a/jobs-service/jobs-service-postgresql/pom.xml
+++ b/jobs-service/jobs-service-postgresql/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>jobs-service</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jobs-service-postgresql</artifactId>

--- a/jobs-service/jobs-service-storage-jpa/pom.xml
+++ b/jobs-service/jobs-service-storage-jpa/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>jobs-service</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jobs-service-storage-jpa</artifactId>

--- a/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/deployment/pom.xml
+++ b/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-service-embedded-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-jobs-service-embedded-deployment</artifactId>
   <name>Jobs Service Embedded Quarkus Add-On - Deployment</name>

--- a/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/pom.xml
+++ b/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-jobs-service</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-jobs-service-embedded-parent</artifactId>
   <packaging>pom</packaging>

--- a/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/runtime/pom.xml
+++ b/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-service-embedded-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-jobs-service-embedded</artifactId>
   <name>Jobs Service Embedded Quarkus Add-On - Runtime</name>

--- a/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/pom.xml
+++ b/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kogito-addons-jobs-service</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-jobs</artifactId>

--- a/jobs-service/kogito-addons-jobs-service/pom.xml
+++ b/jobs-service/kogito-addons-jobs-service/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>jobs-service</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.kie</groupId>

--- a/jobs-service/pom.xml
+++ b/jobs-service/pom.xml
@@ -45,8 +45,6 @@
     <module>kogito-addons-jobs-service</module>
     <module>jobs-service-messaging-kafka</module>
     <module>jobs-service-messaging-http</module>
-    <module>jobs-service-infinispan</module>
-    <module>jobs-service-mongodb</module>
   </modules>
 
   <dependencyManagement>

--- a/jobs-service/pom.xml
+++ b/jobs-service/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-apps-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-apps-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/jobs/jobs-common-embedded/pom.xml
+++ b/jobs/jobs-common-embedded/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>jobs</artifactId>
 		<groupId>org.kie</groupId>
-		<version>999-SNAPSHOT</version>
+		<version>111-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jobs-common-embedded</artifactId>

--- a/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/pom.xml
+++ b/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>kogito-addons-embedded-jobs-jpa</artifactId>
 		<groupId>org.kie</groupId>
-		<version>999-SNAPSHOT</version>
+		<version>111-SNAPSHOT</version>
 	</parent>
 
 

--- a/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-quarkus-embedded-jobs-jpa/pom.xml
+++ b/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-quarkus-embedded-jobs-jpa/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>kogito-addons-embedded-jobs-jpa</artifactId>
 		<groupId>org.kie</groupId>
-		<version>999-SNAPSHOT</version>
+		<version>111-SNAPSHOT</version>
 	</parent>
 
 

--- a/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-springboot-embedded-jobs-jpa/pom.xml
+++ b/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-springboot-embedded-jobs-jpa/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>kogito-addons-embedded-jobs-jpa</artifactId>
 		<groupId>org.kie</groupId>
-		<version>999-SNAPSHOT</version>
+		<version>111-SNAPSHOT</version>
 	</parent>
 
 

--- a/jobs/kogito-addons-embedded-jobs-jpa/pom.xml
+++ b/jobs/kogito-addons-embedded-jobs-jpa/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>jobs</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
 

--- a/jobs/kogito-addons-quarkus-embedded-jobs/pom.xml
+++ b/jobs/kogito-addons-quarkus-embedded-jobs/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>jobs</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
 

--- a/jobs/kogito-addons-springboot-embedded-jobs/pom.xml
+++ b/jobs/kogito-addons-springboot-embedded-jobs/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>jobs</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
 

--- a/jobs/pom.xml
+++ b/jobs/pom.xml
@@ -36,7 +36,6 @@
   <modules>
     <module>jobs-common-embedded</module>
     <module>kogito-addons-quarkus-embedded-jobs</module>
-    <module>kogito-addons-springboot-embedded-jobs</module>
     <module>kogito-addons-embedded-jobs-jpa</module>
   </modules>
 </project>

--- a/jobs/pom.xml
+++ b/jobs/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-apps-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-apps-build-parent/pom.xml</relativePath>
   </parent>
   

--- a/kogito-apps-bom/pom.xml
+++ b/kogito-apps-bom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>kogito-apps</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kogito-apps-build-parent/pom.xml
+++ b/kogito-apps-build-parent/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-apps</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-commons/kogito-ddl/pom.xml
+++ b/persistence-commons/kogito-ddl/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>persistence-commons</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kogito-ddl</artifactId>

--- a/persistence-commons/kogito-ddl/pom.xml
+++ b/persistence-commons/kogito-ddl/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <java.module.name>org.kie.kogito.ddl</java.module.name>
-    <db.scripts.descriptor>src/assembly/multi-repo-zip.xml</db.scripts.descriptor>
+    <db.scripts.descriptor>src/assembly/productized-multi-repo-zip.xml</db.scripts.descriptor>
   </properties>
 
   <dependencies>
@@ -72,17 +72,4 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>productized</id>
-      <activation>
-        <property>
-          <name>productized</name>
-        </property>
-      </activation>
-      <properties>
-        <db.scripts.descriptor>src/assembly/productized-multi-repo-zip.xml</db.scripts.descriptor>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/persistence-commons/persistence-commons-api/pom.xml
+++ b/persistence-commons/persistence-commons-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>persistence-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Kogito Apps :: Persistence Commons API</name>

--- a/persistence-commons/persistence-commons-infinispan/pom.xml
+++ b/persistence-commons/persistence-commons-infinispan/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>persistence-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-commons/persistence-commons-jpa-base/pom.xml
+++ b/persistence-commons/persistence-commons-jpa-base/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>persistence-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-commons/persistence-commons-jpa/pom.xml
+++ b/persistence-commons/persistence-commons-jpa/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>persistence-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-commons/persistence-commons-mongodb-quarkus/pom.xml
+++ b/persistence-commons/persistence-commons-mongodb-quarkus/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>persistence-commons</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>persistence-commons-mongodb-quarkus</artifactId>
   <properties>

--- a/persistence-commons/persistence-commons-mongodb/pom.xml
+++ b/persistence-commons/persistence-commons-mongodb/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>persistence-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-commons/persistence-commons-postgresql/pom.xml
+++ b/persistence-commons/persistence-commons-postgresql/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>persistence-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-commons/persistence-commons-protobuf/pom.xml
+++ b/persistence-commons/persistence-commons-protobuf/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>persistence-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-commons/persistence-commons-redis/pom.xml
+++ b/persistence-commons/persistence-commons-redis/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>persistence-commons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-commons/persistence-commons-reporting-parent/persistence-commons-reporting-api/pom.xml
+++ b/persistence-commons/persistence-commons-reporting-parent/persistence-commons-reporting-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>persistence-commons-reporting-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-commons/persistence-commons-reporting-parent/persistence-commons-reporting-postgresql-base/pom.xml
+++ b/persistence-commons/persistence-commons-reporting-parent/persistence-commons-reporting-postgresql-base/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>persistence-commons-reporting-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-commons/persistence-commons-reporting-parent/persistence-commons-reporting-postgresql-generic/pom.xml
+++ b/persistence-commons/persistence-commons-reporting-parent/persistence-commons-reporting-postgresql-generic/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>persistence-commons-reporting-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-commons/persistence-commons-reporting-parent/pom.xml
+++ b/persistence-commons/persistence-commons-reporting-parent/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>persistence-commons</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-commons/pom.xml
+++ b/persistence-commons/pom.xml
@@ -40,11 +40,7 @@
     <module>persistence-commons-jpa-base</module>
     <module>persistence-commons-jpa</module>
     <module>persistence-commons-postgresql</module>
-    <module>persistence-commons-mongodb</module>
-    <module>persistence-commons-redis</module>
-    <module>persistence-commons-reporting-parent</module>
     <module>kogito-ddl</module>
-    <module>persistence-commons-mongodb-quarkus</module>
   </modules>
 
 </project>

--- a/persistence-commons/pom.xml
+++ b/persistence-commons/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-apps-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-apps-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -28,11 +28,7 @@
   <artifactId>kogito-apps</artifactId>
   <packaging>pom</packaging>
   <name>Kogito Apps</name>
-  <description>Kogito Apps</description>
-  <organization>
-    <name>The Apache Software Foundation</name>
-    <url>https://apache.org/</url>
-  </organization>
+  <description>This repository is a fork of https://github.com/apache/incubator-kie-kogito-apps used for the purposes od SonataFlow.</description>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
@@ -41,42 +37,69 @@
     </license>
   </licenses>
   <scm>
-    <connection>scm:git:https://github.com/apache/incubator-kie-kogito-apps.git</connection>
-    <developerConnection>scm:git:https://github.com/apache/incubator-kie-kogito-apps.git</developerConnection>
-    <url>https://github.com/apache/incubator-kie-kogito-apps</url>
+    <connection>scm:git:https://github.com/kiegroup/kogito-apps.git</connection>
+    <developerConnection>scm:git:https://github.com/kiegroup/kogito-apps.git</developerConnection>
+    <url>https://github.com/kiegroup/kogito-apps</url>
   </scm>
-  <developers>
-    <developer>
-      <name>The Apache KIE Team</name>
-      <email>dev@kie.apache.org</email>
-      <url>https://kie.apache.org</url>
-      <organization>Apache Software Foundation</organization>
-      <organizationUrl>http://apache.org/</organizationUrl>
-    </developer>
-  </developers>
-  <mailingLists>
-    <mailingList>
-      <name>Development List</name>
-      <subscribe>dev-subscribe@kie.apache.org</subscribe>
-      <unsubscribe>dev-unsubscribe@kie.apache.org</unsubscribe>
-      <post>dev@kie.apache.org</post>
-      <archive>https://lists.apache.org/list.html?dev@kie.apache.org</archive>
-    </mailingList>
-    <mailingList>
-      <name>User List</name>
-      <subscribe>users-subscribe@kie.apache.org</subscribe>
-      <unsubscribe>users-unsubscribe@kie.apache.org</unsubscribe>
-      <post>users@kie.apache.org</post>
-      <archive>https://lists.apache.org/list.html?users@kie.apache.org</archive>
-    </mailingList>
-    <mailingList>
-      <name>Commits List</name>
-      <subscribe>commits-subscribe@kie.apache.org</subscribe>
-      <unsubscribe>commits-unsubscribe@kie.apache.org</unsubscribe>
-      <post>commits@kie.apache.org</post>
-      <archive>https://lists.apache.org/list.html?commits@kie.apache.org</archive>
-    </mailingList>
-  </mailingLists>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </repository>
+    <snapshotRepository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+    <repository>
+      <id>github</id>
+      <name>GitHub Repository</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </repository>
+    <repository>
+      <id>redhat-ga-repository</id>
+      <url>https://maven.repository.redhat.com/ga</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <name>Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>github</id>
+      <name>GitHub Repository</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>redhat-ga-plugin-repository</id>
+      <url>https://maven.repository.redhat.com/ga</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.outputTimestamp>2024-01-16T00:00:00Z</project.build.outputTimestamp>
@@ -96,17 +119,6 @@
       </plugins>
     </pluginManagement>
   </build>
-  <repositories>
-    <!-- useful to resolve parent pom when it is a SNAPSHOT -->
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>https://repository.apache.org/snapshots</url>
-    </repository>
-  </repositories>
   <modules>
     <module>kogito-apps-bom</module>
     <module>kogito-apps-build-parent</module>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
   <artifactId>kogito-apps</artifactId>
   <packaging>pom</packaging>
   <name>Kogito Apps</name>
+  <organization>
+    <name>The Apache Software Foundation</name>
+    <url>https://apache.org/</url>
+  </organization>
   <description>This repository is a fork of https://github.com/apache/incubator-kie-kogito-apps used for the purposes od SonataFlow.</description>
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath/>
   </parent>
   <artifactId>kogito-apps</artifactId>
@@ -59,7 +59,7 @@
     <repository>
       <id>central</id>
       <name>Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
       <id>github</id>
@@ -81,7 +81,7 @@
     <pluginRepository>
       <id>central</id>
       <name>Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
     </pluginRepository>
     <pluginRepository>
       <id>github</id>

--- a/pom.xml
+++ b/pom.xml
@@ -125,11 +125,6 @@
     <module>persistence-commons</module>
     <module>jobs-service</module>
     <module>data-index</module>
-    <module>data-audit</module>
-    <module>security-commons</module>
-    <module>explainability</module>
-    <module>trusty</module>
-    <module>jitexecutor</module>
     <module>jobs</module>
   </modules>
   <profiles>
@@ -154,8 +149,6 @@
       <modules>
         <module>kogito-apps-bom</module>
         <module>kogito-apps-build-parent</module>
-        <module>explainability</module>
-        <module>trusty</module>
       </modules>
     </profile>
     <profile>

--- a/security-commons/pom.xml
+++ b/security-commons/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-apps-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-apps-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/trusty/pom.xml
+++ b/trusty/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-apps-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-apps-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/trusty/trusty-service/pom.xml
+++ b/trusty/trusty-service/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>trusty</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/trusty/trusty-service/trusty-service-api/pom.xml
+++ b/trusty/trusty-service/trusty-service-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>trusty-service</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/trusty/trusty-service/trusty-service-common/pom.xml
+++ b/trusty/trusty-service/trusty-service-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>trusty-service</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/trusty/trusty-service/trusty-service-infinispan/pom.xml
+++ b/trusty/trusty-service/trusty-service-infinispan/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>trusty-service</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/trusty/trusty-service/trusty-service-postgresql/pom.xml
+++ b/trusty/trusty-service/trusty-service-postgresql/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>trusty-service</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/trusty/trusty-service/trusty-service-redis/pom.xml
+++ b/trusty/trusty-service/trusty-service-redis/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>trusty-service</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/trusty/trusty-storage/pom.xml
+++ b/trusty/trusty-storage/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>trusty</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/trusty/trusty-storage/trusty-storage-api/pom.xml
+++ b/trusty/trusty-storage/trusty-storage-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>trusty-storage</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/trusty/trusty-storage/trusty-storage-common/pom.xml
+++ b/trusty/trusty-storage/trusty-storage-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>trusty-storage</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/trusty/trusty-storage/trusty-storage-infinispan/pom.xml
+++ b/trusty/trusty-storage/trusty-storage-infinispan/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>trusty-storage</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/trusty/trusty-storage/trusty-storage-postgresql/pom.xml
+++ b/trusty/trusty-storage/trusty-storage-postgresql/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>trusty-storage</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/trusty/trusty-storage/trusty-storage-redis/pom.xml
+++ b/trusty/trusty-storage/trusty-storage-redis/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>trusty-storage</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-963

Had to recreate this PR to get the latest changes from kogito-pipelines in PR checks.

- Updates distributionManagement and repositories section.
- Changes 999-SNAPSHOT to 111-SNAPSHOT to distinct from Apache snapshots.
- Removed modules defined in the productized/modules directory from pom.xmls. (Basically the remove_modules.sh script was executed on this branch).
- Makes the productized profile behaviour the default one.

Related PRs:
https://github.com/kiegroup/drools/pull/182
https://github.com/kiegroup/kogito-runtimes/pull/177
https://github.com/kiegroup/kogito-examples/pull/108
https://github.com/kubesmarts/kie-tools/pull/301