### PR TITLE
[SRVLOGIC-1137] Restore host in ProcessDefinition serviceUrl

### DIFF
--- a/data-index/data-index-graphql/src/main/java/org/kie/kogito/index/graphql/AbstractGraphQLSchemaManager.java
+++ b/data-index/data-index-graphql/src/main/java/org/kie/kogito/index/graphql/AbstractGraphQLSchemaManager.java
@@ -18,8 +18,13 @@
  */
 package org.kie.kogito.index.graphql;
 
-import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.ServiceLoader.Provider;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -30,8 +35,14 @@ import org.kie.kogito.index.api.KogitoRuntimeClient;
 import org.kie.kogito.index.graphql.query.GraphQLQueryOrderByParser;
 import org.kie.kogito.index.graphql.query.GraphQLQueryParser;
 import org.kie.kogito.index.graphql.query.GraphQLQueryParserRegistry;
-import org.kie.kogito.index.model.*;
+import org.kie.kogito.index.model.Job;
+import org.kie.kogito.index.model.Node;
+import org.kie.kogito.index.model.NodeInstance;
+import org.kie.kogito.index.model.ProcessDefinition;
+import org.kie.kogito.index.model.ProcessDefinitionKey;
+import org.kie.kogito.index.model.ProcessInstance;
 import org.kie.kogito.index.model.Timer;
+import org.kie.kogito.index.model.URIInfo;
 import org.kie.kogito.index.service.DataIndexServiceException;
 import org.kie.kogito.index.storage.DataIndexStorageService;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
@@ -157,7 +168,7 @@ public abstract class AbstractGraphQLSchemaManager implements GraphQLSchemaManag
         if (source == null || source.getEndpoint() == null) {
             return null;
         }
-        return URI.create(source.getEndpoint()).getPath();
+        return URIInfo.buildURIInfo(source).truncatedURI().toString();
     }
 
     public String getProcessInstanceServiceUrl(DataFetchingEnvironment env) {

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/service/graphql/GraphQLSchemaManagerTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/service/graphql/GraphQLSchemaManagerTest.java
@@ -19,6 +19,7 @@
 package org.kie.kogito.index.service.graphql;
 
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.index.model.ProcessDefinition;
 import org.kie.kogito.index.model.ProcessInstance;
 import org.mockito.Mockito;
 
@@ -55,6 +56,24 @@ public class GraphQLSchemaManagerTest {
         assertThat(schemaManager.getProcessInstanceServiceUrl(getEnv("demo.orderItems", "http://localhost:8080/orderItems"))).isEqualTo("http://localhost:8080");
     }
 
+    @Test
+    public void testNullProcessDefinitionServiceUrl() {
+        assertThat(schemaManager.getProcessDefinitionServiceUrl(getDefEnv(null, null, null))).isNull();
+        assertThat(schemaManager.getProcessDefinitionServiceUrl(getDefEnv("travels", null, null))).isNull();
+    }
+
+    @Test
+    public void testUrlProcessDefinitionServiceUrl() {
+        assertThat(schemaManager.getProcessDefinitionServiceUrl(getDefEnv("travels", "1.0", "http://localhost:8080/travels"))).isEqualTo("http://localhost:8080");
+        assertThat(schemaManager.getProcessDefinitionServiceUrl(getDefEnv("travels", "http://travels.example.com/travels"))).isEqualTo("http://travels.example.com");
+    }
+
+    @Test
+    public void testUrlWithVersionProcessDefinitionServiceUrl() {
+        assertThat(schemaManager.getProcessDefinitionServiceUrl(getDefEnv("callbackstatetimeouts", "0.0.1", "http://callbackstatetimeouts.example.com/callbackstatetimeouts/0.0.1")))
+                .isEqualTo("http://callbackstatetimeouts.example.com");
+    }
+
     private DataFetchingEnvironment getEnv(String processId, String endpoint) {
         DataFetchingEnvironment env = Mockito.mock(DataFetchingEnvironment.class);
         Mockito.when(env.getSource()).thenReturn(getProcessInstance(processId, endpoint));
@@ -66,5 +85,23 @@ public class GraphQLSchemaManagerTest {
         pi.setProcessId(processId);
         pi.setEndpoint(endpoint);
         return pi;
+    }
+
+    private DataFetchingEnvironment getDefEnv(String id, String endpoint) {
+        return getDefEnv(id, null, endpoint);
+    }
+
+    private DataFetchingEnvironment getDefEnv(String id, String version, String endpoint) {
+        DataFetchingEnvironment env = Mockito.mock(DataFetchingEnvironment.class);
+        Mockito.when(env.getSource()).thenReturn(getProcessDefinition(id, version, endpoint));
+        return env;
+    }
+
+    private ProcessDefinition getProcessDefinition(String id, String version, String endpoint) {
+        ProcessDefinition pd = new ProcessDefinition();
+        pd.setId(id);
+        pd.setVersion(version);
+        pd.setEndpoint(endpoint);
+        return pd;
     }
 }


### PR DESCRIPTION
`getProcessDefinitionServiceUrl` was using `URI.create(endpoint).getPath()`, which drops the scheme and host and keeps only the path. 

This made serviceUrl a relative path such as `/callbackstatetimeouts/0.0.1` instead of the service address, e.g. `http://callbackstatetimeouts.example.com`.

`getProcessInstanceServiceUrl` already handles this correctly using `URIInfo.buildURIInfo(...).truncatedURI()`, which strips the trailing id/version segments while keeping the host. Use the same approach for ProcessDefinition, via the existing (previously unused) `URIInfo.buildURIInfo(ProcessDefinition)` overload.

This is MIDSTREAM if you want to send your PR to UPSTREAM use https://github.com/apache/incubator-kie-kogito-apps

**REQUIRED** Add link to SRVLOGIC Jira!

https://redhat.atlassian.net/browse/SRVLOGIC-1137

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `SRVLOGIC-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] SRVLOGIC-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.

[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>
